### PR TITLE
Remove tags HTML e troca por Markdown puro a fim de linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,28 @@
-<img src="./.github/preview.png" width="100%" />
+# Meu Voto 2024
 
-<p align="center">
-  <img alt="GitHub top language" src="https://img.shields.io/github/languages/top/leovargasdev/o-meu-voto.svg" />
-  
-  <img alt="GitHub language count" src="https://img.shields.io/github/languages/count/leovargasdev/o-meu-voto.svg" />
-  
-  <img alt="Repository size" src="https://img.shields.io/github/repo-size/leovargasdev/o-meu-voto.svg" />
+![Preview](./.github/preview.png)
 
-  <a href="https://github.com/leovargasdev/o-meu-voto/commits/master">
-    <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/leovargasdev/o-meu-voto.svg" />
-  </a>
-  
-  <a href="https://github.com/leovargasdev/o-meu-voto/issues">
-    <img alt="Repository issues" src="https://img.shields.io/github/issues/leovargasdev/o-meu-voto.svg" />
-  </a>
-</p>
+<div align="center">
 
+![GitHub top language](https://img.shields.io/github/languages/top/leovargasdev/o-meu-voto.svg)
+![GitHub language count](https://img.shields.io/github/languages/count/leovargasdev/o-meu-voto.svg)
+![Repository size](https://img.shields.io/github/repo-size/leovargasdev/o-meu-voto.svg)
+[![GitHub last commit](https://img.shields.io/github/last-commit/leovargasdev/o-meu-voto.svg)](https://github.com/leovargasdev/o-meu-voto/commits/master)
+[![Repository issues](https://img.shields.io/github/issues/leovargasdev/o-meu-voto.svg)](https://github.com/leovargasdev/o-meu-voto/issues)
+
+</div>
 
 ## 💻 Projeto
 
-[O Meu voto](https://omeuvoto.com.br/) é uma plataforma focada em listar os candidatos das eleições municipais de 2024 no Brasil. 
+[O Meu voto](https://omeuvoto.com.br/) é uma plataforma focada em listar os candidatos das eleições municipais de 2024 no Brasil.
 
 O principal objetivo é promover a transparência e facilitar o acesso às informações públicas, garantindo que os eleitores possam tomar decisões informadas. Todos os dados utilizados nesse projeto estão disponíveis de forma pública no [site do TSE](https://divulgacandcontas.tse.jus.br/divulga/#/home).
 
 ## 🚀 Tecnologias
 
--  [NextJS](https://nextjs.org/)
--  [Sass](https://sass-lang.com/)
--  [TypeScript](https://www.typescriptlang.org/)
-
+- [NextJS](https://nextjs.org/)
+- [Sass](https://sass-lang.com/)
+- [TypeScript](https://www.typescriptlang.org/)
 
 ## 📥 Rodando localmente
 
@@ -55,4 +49,3 @@ Inicie o servidor
 ```bash
   yarn next
 ```
-


### PR DESCRIPTION
Olá!! Pequeno ajuste no README.md

Seguindo a regra do MD033 - Inline HTML no markdown linting, troquei as tags HTML por Markdown puro, exceto pela div de centralização, que não há outra abordagem.

Ajuste apenas de linting.