### PR TITLE
style: Padding on footer to align with the website's grid

### DIFF
--- a/src/components/Footer/styles.module.scss
+++ b/src/components/Footer/styles.module.scss
@@ -1,6 +1,6 @@
 .container {
   margin-top: auto;
-  padding: 32px 0 12px;
+  padding: 32px 24px 12px;
 
   display: flex;
   align-items: center;
@@ -20,7 +20,7 @@
     }
   }
 
-  @media(max-width: 650px) {
+  @media (max-width: 650px) {
     flex-direction: column;
     row-gap: 16px;
     text-align: center;


### PR DESCRIPTION
Nas telas com width menor que 1500px, os links no footer ficam desalinhados com a grid da página. Esse PR resolve isso.
Exemplo:
![image](https://github.com/user-attachments/assets/2349f1b4-dfa8-46dd-b24b-6b44b78c1f66)
